### PR TITLE
Use dynamic header offset for hash links

### DIFF
--- a/js/priorities.js
+++ b/js/priorities.js
@@ -6,8 +6,9 @@
     if (el && el.nodeName.toLowerCase() === 'details') {
       el.open = true;
     }
-    // Adjust scroll to account for sticky header (approximately 80px)
-    requestAnimationFrame(() => window.scrollBy(0, -80));
+    // Adjust scroll to account for sticky header using computed height
+    const headerH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--header-h')) || 80;
+    requestAnimationFrame(() => window.scrollBy(0, -headerH));
   };
   window.addEventListener('hashchange', hashOpen);
   // Run on initial page load in case a hash is present


### PR DESCRIPTION
## Summary
- compute the sticky header height from the `--header-h` CSS variable with 80px fallback
- apply that height to scroll offset when opening hash-linked details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a703b00fc08330817e3036ba001ef4