### PR TITLE
Clarify donation helper comment

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,8 +2,8 @@
 
 // Donation intake form helper
 // This script enforces Maine campaign finance rules on the client.
-// It caps the donation amount at the statutory limit, and toggles
-// employer/occupation requirements when the gift exceeds $50.
+// It clamps donations to the $1–$600 range and toggles
+// employer/occupation fields when the gift exceeds $50.
 document.addEventListener('DOMContentLoaded', () => {
   const amt = document.querySelector('#amount');
   const emp = document.querySelector('#employer');


### PR DESCRIPTION
## Summary
- clarify donation helper comment to state that it clamps amounts to $1–$600
- note employer/occupation fields toggle when the gift exceeds $50

## Testing
- `node -v`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a702b1aa8883308cd6b61a19c37a89