### PR TITLE
Enforce five-digit ZIP code pattern

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -88,7 +88,7 @@
         <label>Street Address * <input name="addr1" required></label>
         <label>City * <input name="city" required></label>
         <label>State * <input name="state" required maxlength="2"></label>
-        <label>ZIP * <input name="zip" required pattern="\\d{5}(-\\d{4})?"></label>
+        <label>ZIP * <input name="zip" required pattern="[0-9]{5}"></label>
       </fieldset>
 
       <!-- Employer/Occupation: required when amount > $50; toggled via JS. -->


### PR DESCRIPTION
## Summary
- restrict ZIP field in donation form to exactly five digits

## Testing
- `npm test`
- `node - <<'NODE'
const { JSDOM } = require('jsdom');
const fs = require('fs');
const html = fs.readFileSync('donate.html', 'utf8');
const dom = new JSDOM(html);
const input = dom.window.document.querySelector('input[name="zip"]');
console.log('pattern:', input.getAttribute('pattern'));
input.value = '12345';
console.log('12345 valid:', input.checkValidity());
input.value = '1234';
console.log('1234 valid:', input.checkValidity());
input.value = '12345-6789';
console.log('12345-6789 valid:', input.checkValidity());
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a70bb351448330bac1f09d04b90df7