### PR TITLE
Hide honeypot field in donation form

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -70,7 +70,7 @@
     <form name="donations" method="POST" action="/thanks.html"
           data-netlify="true" netlify-honeypot="bot-field" class="form" id="donation-form">
       <input type="hidden" name="form-name" value="donations">
-      <p class="hidden"><label>Don’t fill this out: <input name="bot-field"></label></p>
+      <p class="hp"><label>Don’t fill this out: <input name="bot-field"></label></p>
 
       <!-- Amount input: enforce minimum 1 and maximum 600 -->
       <label>Amount (USD) *


### PR DESCRIPTION
## Summary
- hide donation form honeypot using `.hp` class

## Testing
- `npm test`
- `node` script to confirm honeypot element is off-screen


------
https://chatgpt.com/codex/tasks/task_e_68a70cc8ab0c8330848b4be061c2972e