### PR TITLE
Improve hero button contrast for accessibility

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -369,11 +369,11 @@ section { padding: var(--space-10) 0; }
 
 /* Custom hero CTA colors (kept for any non-ghost buttons) */
 .hero__actions .btn:not(.btn--ghost) {
-  background: #184a45; color: var(--color-accent); border-color: #184a45;
+  background: #184a45; color: #fff; border-color: #184a45;
 }
 .hero__actions .btn:not(.btn--ghost):hover,
 .hero__actions .btn:not(.btn--ghost):focus {
-  background: #293f54; color: var(--color-accent);
+  background: #293f54; color: #fff;
 }
 
 /* Reduced motion: hide moving background */


### PR DESCRIPTION
## Summary
- ensure hero action buttons use high-contrast white text
- maintain contrast on hover/focus states

## Testing
- `npm test`
- `python - <<'PY'
# compute contrast ratio for the hero button colors after change

def luminance(c):
    c = c.lstrip('#')
    r = int(c[0:2],16)/255
    g = int(c[2:4],16)/255
    b = int(c[4:6],16)/255
    def channel(v):
        return v/12.92 if v <= 0.03928 else ((v+0.055)/1.055)**2.4
    r,g,b = channel(r),channel(g),channel(b)
    return 0.2126*r + 0.7152*g + 0.0722*b

def contrast(bg, fg):
    L1 = luminance(bg)
    L2 = luminance(fg)
    L1,L2 = max(L1,L2),min(L1,L2)
    return (L1+0.05)/(L2+0.05)

print('contrast for #184a45 bg with #ffffff text:', round(contrast('#184a45','#ffffff'),2))
print('contrast for hover #293f54 bg with #ffffff text:', round(contrast('#293f54','#ffffff'),2))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a71043e0108330a42446a4d0d76137