### PR TITLE
Use dark brand color for focus outlines

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -501,7 +501,7 @@ nav a { margin-left: var(--space-4); font-weight: 600; }
 /* =========================
    Focus styles
    ========================= */
-:focus-visible { outline: 3px solid var(--color-accent); outline-offset: 2px; }
+:focus-visible { outline: 3px solid var(--color-primary); outline-offset: 2px; }
 
 /* =========================
    Responsive helpers


### PR DESCRIPTION
## Summary
- swap `:focus-visible` outline color to primary brand green for better contrast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a710440bb48330bd9b3c79ce91a453