### PR TITLE
Improve contrast for form notes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -419,7 +419,7 @@ label .req { color: var(--color-accent); font-weight: 700; margin-left: .25rem; 
 .input { width: 100%; padding: .7rem .8rem; border: 1px solid var(--color-border); border-radius: var(--radius-sm); font: inherit; background: #fff; }
 .input::placeholder { color: #9aa2af; }
 
-.form-note.small { color: var(--color-footer-text); margin-bottom: var(--space-4); }
+.form-note.small { color: var(--color-text); margin-bottom: var(--space-4); }
 
 /* Checkboxes: consistent left + vertical alignment */
 .checkbox-row {


### PR DESCRIPTION
## Summary
- use `--color-text` for `.form-note.small`
- ensures small form notes meet contrast requirements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a710487418833080ce80be5e36d8f1