### PR TITLE
Replace hero taglines with non-heading elements

### DIFF
--- a/404.html
+++ b/404.html
@@ -67,7 +67,7 @@
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
-      <h2>Fix what’s broken. Grow smart. Own the results.</h2>
+      <p class="hero__title">Fix what’s broken. Grow smart. Own the results.</p>
       <p>Biddeford’s working‑class future — steady, practical, accountable.</p>
     </div>
   </section>

--- a/contact.html
+++ b/contact.html
@@ -67,7 +67,7 @@
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
-      <h2>Fix what’s broken. Grow smart. Own the results.</h2>
+      <p class="hero__title">Fix what’s broken. Grow smart. Own the results.</p>
       <p>Biddeford’s working‑class future — steady, practical, accountable.</p>
     </div>
   </section>

--- a/priorities.html
+++ b/priorities.html
@@ -67,7 +67,7 @@
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
-      <h2>Fix what’s broken. Grow smart. Own the results.</h2>
+      <p class="hero__title">Fix what’s broken. Grow smart. Own the results.</p>
       <p>Biddeford’s working‑class future — steady, practical, accountable.</p>
     </div>
   </section>

--- a/privacy.html
+++ b/privacy.html
@@ -67,7 +67,7 @@
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
-      <h2>Fix what’s broken. Grow smart. Own the results.</h2>
+      <p class="hero__title">Fix what’s broken. Grow smart. Own the results.</p>
       <p>Biddeford’s working‑class future — steady, practical, accountable.</p>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Convert hero tagline `<h2>` elements to `<p class="hero__title">` on 404, contact, privacy, and priorities pages
- Maintain sequential document outline with page content now beginning at `<h1>`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a71049963c8330bfea6d718a3c700d