### PR TITLE
Wrap nav toggle icon in aria-hidden span

### DIFF
--- a/404.html
+++ b/404.html
@@ -45,7 +45,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">

--- a/about.html
+++ b/about.html
@@ -42,7 +42,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">

--- a/contact.html
+++ b/contact.html
@@ -45,7 +45,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">

--- a/donate.html
+++ b/donate.html
@@ -43,7 +43,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">

--- a/events.html
+++ b/events.html
@@ -43,7 +43,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">

--- a/porch.html
+++ b/porch.html
@@ -48,7 +48,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">

--- a/priorities.html
+++ b/priorities.html
@@ -45,7 +45,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">

--- a/privacy.html
+++ b/privacy.html
@@ -45,7 +45,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">

--- a/support.html
+++ b/support.html
@@ -43,7 +43,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">

--- a/thanks.html
+++ b/thanks.html
@@ -33,7 +33,7 @@
       </a>
       <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Menu</span>
-        ☰
+        <span aria-hidden="true">☰</span>
       </button>
       <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
         <ul class="nav__list">


### PR DESCRIPTION
## Summary
- hide decorative menu icon from assistive tech by wrapping nav toggle glyph in aria-hidden span
- mirror update across all pages with `.nav-toggle`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a71050d0288330986f6b917c2ba571