### PR TITLE
Hide honeypot fields from assistive tech

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -70,7 +70,7 @@
     <form name="donations" method="POST" action="/thanks.html"
           data-netlify="true" netlify-honeypot="bot-field" class="form" id="donation-form">
       <input type="hidden" name="form-name" value="donations">
-      <p class="hp"><label>Don’t fill this out: <input name="bot-field"></label></p>
+      <p class="hp" aria-hidden="true" tabindex="-1"><label>Don’t fill this out: <input name="bot-field"></label></p>
 
       <!-- Amount input: enforce minimum 1 and maximum 600 -->
       <label>Amount (USD) *

--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@
         >
           <!-- Netlify wiring -->
           <input type="hidden" name="form-name" value="support">
-          <p class="hp">
+          <p class="hp" aria-hidden="true" tabindex="-1">
             <label>Don’t fill this out if you’re human: <input name="bot-field"></label>
           </p>
 

--- a/porch.html
+++ b/porch.html
@@ -120,7 +120,7 @@
           <!-- RSVP form -->
           <form class="form-grid" action="/thanks.html" name="porch" method="POST" data-netlify="true" netlify-honeypot="bot-field">
             <input type="hidden" name="form-name" value="porch">
-            <p class="hp">
+            <p class="hp" aria-hidden="true" tabindex="-1">
               <label>Don’t fill this out if you’re human: <input name="bot-field"></label>
             </p>
 

--- a/support.html
+++ b/support.html
@@ -78,7 +78,7 @@
           netlify-honeypot="bot-field"
         >
           <input type="hidden" name="form-name" value="support">
-          <p class="hp">
+          <p class="hp" aria-hidden="true" tabindex="-1">
             <label>Don’t fill this out if you’re human: <input name="bot-field"></label>
           </p>
 


### PR DESCRIPTION
## Summary
- prevent Netlify honeypot paragraphs from being announced by screen readers by adding `aria-hidden` and `tabindex` attributes

## Testing
- `npm test`
- `node -e "const fs=require('fs'); const {JSDOM}=require('jsdom'); const files=['donate.html','support.html','porch.html','index.html']; for(const f of files){ const dom=new JSDOM(fs.readFileSync(f,'utf8')); const hp=dom.window.document.querySelector('p.hp'); console.log(f, hp && hp.getAttribute('aria-hidden'), hp && hp.getAttribute('tabindex')); }"`


------
https://chatgpt.com/codex/tasks/task_e_68a71059184083309b4e1eed2549f4be