### PR TITLE
Remove unused emphasis tag from Open Porch page

### DIFF
--- a/porch.html
+++ b/porch.html
@@ -91,7 +91,7 @@
           <p class="kicker">What to expect</p>
           <h2>Meet, listen, and solve locally</h2>
           <p>
-            <em></em> Pull up a chair and tell me what’s working, what isn’t, and what you’d fix first. If you need accessibility accommodations, note them below and I’ll make it work.
+            Pull up a chair and tell me what’s working, what isn’t, and what you’d fix first. If you need accessibility accommodations, note them below and I’ll make it work.
           </p>
 
           <div class="event-meta" itemscope itemtype="https://schema.org/Event">


### PR DESCRIPTION
## Summary
- remove stray empty `<em>` tag before the "Pull up a chair" paragraph on the Open Porch page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a710c6a6608330aaa48e667aa226f0