### PR TITLE
Sanitize URL hash when navigating priorities

### DIFF
--- a/__tests__/prioritiesHash.test.js
+++ b/__tests__/prioritiesHash.test.js
@@ -1,0 +1,45 @@
+const { JSDOM } = require('jsdom');
+
+describe('priorities hash handling', () => {
+  const loadWithHash = (hash) => {
+    const dom = new JSDOM('<details id="safe"></details>', { url: 'https://example.org/' });
+    const { window } = dom;
+    window.location.hash = hash;
+
+    global.window = window;
+    global.document = window.document;
+    global.location = window.location;
+    window.requestAnimationFrame = (fn) => fn();
+    window.scrollBy = jest.fn();
+    global.requestAnimationFrame = window.requestAnimationFrame;
+    global.getComputedStyle = () => ({ getPropertyValue: () => '0' });
+    document.querySelector = jest.fn(() => ({ nodeName: 'details' }));
+
+    jest.isolateModules(() => {
+      require('../js/priorities');
+    });
+
+    return { query: document.querySelector, window };
+  };
+
+  afterEach(() => {
+    if (global.window) {
+      global.window.close();
+    }
+    delete global.window;
+    delete global.document;
+    delete global.location;
+    delete global.getComputedStyle;
+    delete global.requestAnimationFrame;
+  });
+
+  test('ignores malicious hashes', () => {
+    const { query } = loadWithHash('#<img src=x>');
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  test('processes safe hashes', () => {
+    const { query } = loadWithHash('#safe');
+    expect(query).toHaveBeenCalledWith('#safe');
+  });
+});

--- a/js/priorities.js
+++ b/js/priorities.js
@@ -2,7 +2,12 @@
   // When navigating via hash links, open the corresponding <details>
   const hashOpen = () => {
     if (!location.hash) return;
-    const el = document.querySelector(location.hash);
+
+    const hash = location.hash.slice(1);
+    const allowed = /^[a-z0-9\-_]+$/i;
+    if (!allowed.test(hash)) return;
+
+    const el = document.querySelector(`#${hash}`);
     if (el && el.nodeName.toLowerCase() === 'details') {
       el.open = true;
     }


### PR DESCRIPTION
## Summary
- Sanitize `location.hash` before querying DOM and only process safe hashes
- Add unit tests to ensure malicious hashes are ignored and valid ones are handled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a71a7a9bcc833097e7f3316966babb