### PR TITLE
Add content security policy header

### DIFF
--- a/_headers
+++ b/_headers
@@ -3,7 +3,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
-
+  Content-Security-Policy: default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.gstatic.com;
 # Cache static assets aggressively and HTML sparingly
 /assets/*
   Cache-Control: public, max-age=2592000, immutable


### PR DESCRIPTION
## Summary
- add CSP header to restrict asset loading to first-party resources and required font providers
- format headers file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a71a7e72488330bf700c4c2c95fe40