### PR TITLE
Add Netlify functions for validated form submissions

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -76,7 +76,7 @@
 <section>
 <h1>Contact</h1>
   <p>Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or use the form below.</p>
-  <form action="/thanks.html" name="contact" method="POST" data-netlify="true" netlify-honeypot="bot-field">
+  <form action="/.netlify/functions/contact" name="contact" method="POST">
     <input type="hidden" name="form-name" value="contact">
     <!-- Hidden honeypot field to reduce spam submissions -->
     <input type="hidden" name="bot-field">

--- a/donate.html
+++ b/donate.html
@@ -66,9 +66,9 @@
       Contributions are not tax‑deductible. Maine law requires us to collect your name and address for contributions over $10 and your employer and occupation for contributors giving more than $50 in a reporting period. Maximum contribution is $600 per person per election.
     </p>
 
-    <!-- Donation intake form: uses Netlify for collection. Swap action with your payment processor later. -->
-    <form name="donations" method="POST" action="/thanks.html"
-          data-netlify="true" netlify-honeypot="bot-field" class="form" id="donation-form">
+    <!-- Donation intake form handled by a Netlify Function -->
+    <form name="donations" method="POST" action="/.netlify/functions/donate"
+          class="form" id="donation-form">
       <input type="hidden" name="form-name" value="donations">
       <p class="hp" aria-hidden="true" tabindex="-1"><label>Don’t fill this out: <input name="bot-field"></label></p>
 

--- a/netlify/functions/contact.js
+++ b/netlify/functions/contact.js
@@ -1,0 +1,44 @@
+const querystring = require('querystring');
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      body: 'Method Not Allowed',
+    };
+  }
+
+  const data = querystring.parse(event.body);
+  const errors = [];
+
+  if (data['bot-field']) {
+    errors.push('Spam detected');
+  }
+
+  ['name', 'email', 'message'].forEach((field) => {
+    if (!data[field]) {
+      errors.push(`Missing ${field}`);
+    }
+  });
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (data.email && !emailRegex.test(data.email)) {
+    errors.push('Invalid email');
+  }
+
+  if (errors.length > 0) {
+    console.warn('Invalid contact attempt', { errors, data });
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ message: 'Invalid submission', errors }),
+    };
+  }
+
+  console.log('Contact submission accepted', { name: data.name, email: data.email });
+
+  return {
+    statusCode: 303,
+    headers: { Location: '/thanks.html' },
+    body: ''
+  };
+};

--- a/netlify/functions/donate.js
+++ b/netlify/functions/donate.js
@@ -1,0 +1,67 @@
+const querystring = require('querystring');
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      body: 'Method Not Allowed',
+    };
+  }
+
+  const data = querystring.parse(event.body);
+  const errors = [];
+
+  // Honeypot to deter bots
+  if (data['bot-field']) {
+    errors.push('Spam detected');
+  }
+
+  // Validate amount between 1 and 600
+  const amount = parseFloat(data.amount);
+  if (isNaN(amount) || amount < 1 || amount > 600) {
+    errors.push('Invalid amount');
+  }
+
+  const requiredFields = ['first_name', 'last_name', 'email', 'addr1', 'city', 'state', 'zip', 'affirm_citizen', 'affirm_ownfunds'];
+  requiredFields.forEach((field) => {
+    if (!data[field]) {
+      errors.push(`Missing ${field}`);
+    }
+  });
+
+  // Employer and occupation required when amount > 50
+  if (amount > 50) {
+    if (!data.employer) errors.push('Missing employer');
+    if (!data.occupation) errors.push('Missing occupation');
+  }
+
+  // Basic pattern checks
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (data.email && !emailRegex.test(data.email)) {
+    errors.push('Invalid email');
+  }
+
+  if (data.state && !/^[A-Za-z]{2}$/.test(data.state)) {
+    errors.push('Invalid state');
+  }
+
+  if (data.zip && !/^\d{5}(-\d{4})?$/.test(data.zip)) {
+    errors.push('Invalid ZIP');
+  }
+
+  if (errors.length > 0) {
+    console.warn('Invalid donation attempt', { errors, data });
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ message: 'Invalid submission', errors }),
+    };
+  }
+
+  console.log('Donation submission accepted', { amount, email: data.email });
+
+  return {
+    statusCode: 303,
+    headers: { Location: '/thanks.html' },
+    body: ''
+  };
+};


### PR DESCRIPTION
## Summary
- handle donations via Netlify Function with server-side validation and logging
- add Netlify Function for contact form submissions
- point donation and contact forms to new serverless endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a71a8cb6848330b7638a20e9cc8ac8