### PR TITLE
Restore Open Porch hero background image

### DIFF
--- a/porch.html
+++ b/porch.html
@@ -71,12 +71,7 @@
   <main id="main">
     <section
       class="op-banner"
-      style="--op-banner: image-set(
-        url('/assets/open-porch-banner-1600.webp') type('image/webp') 1x,
-        url('/assets/open-porch-banner-2000.webp') type('image/webp') 2x,
-        url('/assets/open-porch-banner-1600.jpg')  type('image/jpeg') 1x,
-        url('/assets/open-porch-banner-2000.jpg')  type('image/jpeg') 2x
-      );"
+      style="--op-banner: image-set(url('/assets/open-porch-banner-1600.webp') type('image/webp') 1x, url('/assets/open-porch-banner-2000.webp') type('image/webp') 2x, url('/assets/open-porch-banner-1600.jpg') type('image/jpeg') 1x, url('/assets/open-porch-banner-2000.jpg') type('image/jpeg') 2x);"
       aria-label="Open Porch banner">
       <div class="container">
         <h1>Open Porch</h1>


### PR DESCRIPTION
## Summary
- ensure Open Porch hero section defines `--op-banner` with responsive `image-set` sources
- confirm `.op-banner` CSS continues to apply the variable

## Testing
- `npm test`
- `node -e "const fs=require('fs');const {JSDOM}=require('jsdom');const dom=new (require('jsdom').JSDOM)(fs.readFileSync('porch.html','utf8'));const section=dom.window.document.querySelector('.op-banner');console.log(section.getAttribute('style'));"`


------
https://chatgpt.com/codex/tasks/task_e_68a71f75e0e0833089faed3e00aa0a98