### PR TITLE
fix: include sans-serif fallback for OG image

### DIFF
--- a/assets/og-default.svg
+++ b/assets/og-default.svg
@@ -6,6 +6,6 @@
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#g)"/>
-  <text x="60" y="160" font-family="Inter, Arial" font-size="64" font-weight="700" fill="#e8efea">Sam Pecor</text>
-  <text x="60" y="230" font-family="Inter, Arial" font-size="40" fill="#e8efea">Biddeford City Council — Ward 7</text>
+  <text x="60" y="160" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="700" fill="#e8efea">Sam Pecor</text>
+  <text x="60" y="230" font-family="Inter, Arial, sans-serif" font-size="40" fill="#e8efea">Biddeford City Council — Ward 7</text>
 </svg>


### PR DESCRIPTION
## Summary
- ensure Open Graph default image uses `Inter, Arial, sans-serif`

## Testing
- `NODE_PATH=$(npm root -g) npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7278989d88330b28a7e05afc0e55f