### PR TITLE
chore: centralize font loading

### DIFF
--- a/404.html
+++ b/404.html
@@ -28,9 +28,6 @@
     <meta name="twitter:title" content="Page not found — Sam Pecor">
     <meta name="twitter:description" content="The page you’re looking for doesn’t exist.">
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-<!-- Preconnect and load Inter font family for consistent typography -->
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <!-- Accessible skip link for keyboard users -->

--- a/about.html
+++ b/about.html
@@ -27,8 +27,6 @@
   <meta name="twitter:description" content="Meet Sam: background, experience, and why he's running to deliver practical results for Biddeford’s Ward 7.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
   <link rel="stylesheet" href="/css/styles.css">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/contact.html
+++ b/contact.html
@@ -28,9 +28,6 @@
     <meta name="twitter:title" content="Contact — Sam Pecor">
     <meta name="twitter:description" content="Email the campaign or send a message using the contact form.">
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <!-- Preconnect and load Inter font family for consistent typography -->
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <!-- Accessible skip link for keyboard users -->

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
 /* =========================
    Design Tokens (Semantic)
    ========================= */

--- a/donate.html
+++ b/donate.html
@@ -28,8 +28,6 @@
   <meta name="twitter:description" content="Placeholder: integrate donation provider or ActBlue link later.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
   <link rel="stylesheet" href="/css/styles.css">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/events.html
+++ b/events.html
@@ -28,8 +28,6 @@
   <meta name="twitter:description" content="Join Sam at upcoming events and weekly Open Porch listening sessions.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
   <link rel="stylesheet" href="/css/styles.css">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/index.html
+++ b/index.html
@@ -38,9 +38,6 @@
 <meta name="twitter:description" content="Practical, steady, and accountable local government. Learn about Sam’s plan for housing, infrastructure, and transparent budgeting.">
 <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
 
-<!-- Preconnect and load Inter font family for consistent typography -->
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 
 <script type="application/ld+json">
 {

--- a/porch.html
+++ b/porch.html
@@ -28,9 +28,6 @@
   <meta name="twitter:title" content="Open Porch — Weekly Listening Sessions — Sam Pecor">
   <meta name="twitter:description" content="Join Sam’s weekly Open Porch to share what’s working, flag what isn’t, and shape the plan together.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <!-- Preconnect and load Inter font family for consistent typography -->
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 
   <!-- Preload Open Porch hero for faster LCP -->
   <link rel="preload" href="/assets/open-porch-banner-1600.jpg" as="image" fetchpriority="high">

--- a/priorities.html
+++ b/priorities.html
@@ -28,9 +28,6 @@
     <meta name="twitter:title" content="Our Plan for Biddeford — Sam Pecor">
     <meta name="twitter:description" content="Fix what’s broken, grow smart, and own the results. Explore priorities, goals, and next steps.">
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <!-- Preconnect and load Inter font family for consistent typography -->
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <!-- Accessible skip link for keyboard users -->

--- a/privacy.html
+++ b/privacy.html
@@ -28,9 +28,6 @@
     <meta name="twitter:title" content="Privacy — Sam Pecor">
     <meta name="twitter:description" content="Plain‑English privacy: what we collect and why.">
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <!-- Preconnect and load Inter font family for consistent typography -->
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <!-- Accessible skip link for keyboard users -->

--- a/support.html
+++ b/support.html
@@ -28,8 +28,6 @@
   <meta name="twitter:description" content="Volunteer or receive updates from the campaign.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
   <link rel="stylesheet" href="/css/styles.css">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/thanks.html
+++ b/thanks.html
@@ -15,9 +15,6 @@
   <meta name="msapplication-config" content="/favicons/browserconfig.xml">
   <meta name="theme-color" content="#184a45">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <!-- Preconnect and load Inter font family for consistent typography -->
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/styles.css?v=20250814122120" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- load Inter font via global stylesheet
- remove redundant font link tags from pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7278e0e3c8330bcf64251ce6f6f12