### PR TITLE
fix: improve banner background fallback

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -631,7 +631,10 @@ nav a { margin-left: var(--space-4); font-weight: 600; }
 .op-banner {
   position: relative;
   color: #fff;
-  background: center/cover no-repeat var(--op-banner, url('/assets/open-porch-placeholder.svg'));
+  background-image: var(--op-banner, url('/assets/open-porch-placeholder.svg'));
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
   padding: clamp(2.5rem, 6vw, 6rem) 0;
 }
 .op-banner::after {

--- a/porch.html
+++ b/porch.html
@@ -68,7 +68,7 @@
   <main id="main">
     <section
       class="op-banner"
-      style="--op-banner: image-set(url('/assets/open-porch-banner-1600.webp') type('image/webp') 1x, url('/assets/open-porch-banner-2000.webp') type('image/webp') 2x, url('/assets/open-porch-banner-1600.jpg') type('image/jpeg') 1x, url('/assets/open-porch-banner-2000.jpg') type('image/jpeg') 2x);"
+      style="--op-banner: -webkit-image-set(url('/assets/open-porch-banner-1600.webp') type('image/webp') 1x, url('/assets/open-porch-banner-2000.webp') type('image/webp') 2x, url('/assets/open-porch-banner-1600.jpg') type('image/jpeg') 1x, url('/assets/open-porch-banner-2000.jpg') type('image/jpeg') 2x); --op-banner: image-set(url('/assets/open-porch-banner-1600.webp') type('image/webp') 1x, url('/assets/open-porch-banner-2000.webp') type('image/webp') 2x, url('/assets/open-porch-banner-1600.jpg') type('image/jpeg') 1x, url('/assets/open-porch-banner-2000.jpg') type('image/jpeg') 2x);"
       aria-label="Open Porch banner">
       <div class="container">
         <h1>Open Porch</h1>


### PR DESCRIPTION
## Summary
- replace `.op-banner` background shorthand with explicit properties for broader support
- add prefixed and standard `image-set` values to Open Porch banner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a72b02e00883308681405688d6a7ef