### PR TITLE
Refactor shared header and footer into reusable partials

### DIFF
--- a/404.html
+++ b/404.html
@@ -30,37 +30,7 @@
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
 </head>
 <body>
-  <!-- Accessible skip link for keyboard users -->
-  <a class="skip-link" href="#main">Skip to content</a>
-  <!-- Unified sticky header and navigation bar -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">
-              Donate
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!--#include virtual="/partials/header.html" -->
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
@@ -76,14 +46,6 @@
 </section>
 
 </main>
-<footer class="footer">
-  <div class="container">
-    <!-- Required campaign disclaimer -->
-    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207‑205‑2680</a>.</div>
-  </div>
-</footer>
-  <!-- Navigation and header JS -->
-  <script src="/js/nav.js" defer></script>
+<!--#include virtual="/partials/footer.html" -->
 </body>
 </html>

--- a/__tests__/partials.test.js
+++ b/__tests__/partials.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const root = path.join(__dirname, '..');
+const htmlFiles = fs
+  .readdirSync(root)
+  .filter((f) => f.endsWith('.html') && !f.startsWith('partial'));
+
+const headerPartial = fs.readFileSync(path.join(root, 'partials', 'header.html'), 'utf8');
+const footerPartial = fs.readFileSync(path.join(root, 'partials', 'footer.html'), 'utf8');
+
+const headerDOM = new JSDOM(headerPartial);
+const expectedHeader = headerDOM.window.document.querySelector('header').outerHTML;
+const expectedSkip = headerDOM.window.document.querySelector('.skip-link').outerHTML;
+const footerDOM = new JSDOM(footerPartial);
+const expectedFooter = footerDOM.window.document.querySelector('footer').outerHTML;
+
+describe('shared partials', () => {
+  htmlFiles.forEach((file) => {
+    test(`${file} renders shared header and footer`, () => {
+      const filePath = path.join(root, file);
+      const raw = fs.readFileSync(filePath, 'utf8');
+      expect(raw).toContain('<!--#include virtual="/partials/header.html" -->');
+      expect(raw).toContain('<!--#include virtual="/partials/footer.html" -->');
+
+      const rendered = raw
+        .replace('<!--#include virtual="/partials/header.html" -->', headerPartial)
+        .replace('<!--#include virtual="/partials/footer.html" -->', footerPartial);
+
+      const dom = new JSDOM(rendered);
+      const header = dom.window.document.querySelector('header').outerHTML;
+      const skip = dom.window.document.querySelector('.skip-link').outerHTML;
+      const footer = dom.window.document.querySelector('footer').outerHTML;
+
+      expect(header).toBe(expectedHeader);
+      expect(skip).toBe(expectedSkip);
+      expect(footer).toBe(expectedFooter);
+    });
+  });
+});

--- a/about.html
+++ b/about.html
@@ -29,34 +29,7 @@
   <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main">Skip to content</a>
-  <!-- Unified sticky header and navigation bar -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">Donate</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!--#include virtual="/partials/header.html" -->
   <main id="main">
     <!-- Page intro -->
     <section class="section--alt">
@@ -122,14 +95,6 @@
     </section>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <!-- Required campaign disclaimer -->
-      <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-      <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207‑205‑2680</a>.</div>
-    </div>
-  </footer>
-
-  <script src="/js/nav.js" defer></script>
+  <!--#include virtual="/partials/footer.html" -->
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -30,37 +30,7 @@
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
 </head>
 <body>
-  <!-- Accessible skip link for keyboard users -->
-  <a class="skip-link" href="#main">Skip to content</a>
-  <!-- Unified sticky header and navigation bar -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">
-              Donate
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!--#include virtual="/partials/header.html" -->
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
@@ -87,17 +57,9 @@
   </form>
 </section>
 
-</main>
-<footer class="footer">
-  <div class="container">
-    <!-- Required campaign disclaimer -->
-    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207‑205‑2680</a>.</div>
-  </div>
-</footer>
-  <!-- Navigation and header JS -->
+  </main>
+  <!--#include virtual="/partials/footer.html" -->
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
-  <script src="/js/nav.js" defer></script>
   <script src="/js/captcha.js" defer></script>
-</body>
-</html>
+  </body>
+  </html>

--- a/donate.html
+++ b/donate.html
@@ -29,36 +29,9 @@
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
   <link rel="stylesheet" href="/css/styles.css">
 </head>
-<body>
-  <a class="skip-link" href="#main">Skip to content</a>
-  <!-- Unified sticky header and navigation bar -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">Donate</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
-  <main id="main" class="container narrow">
+  <body>
+    <!--#include virtual="/partials/header.html" -->
+    <main id="main" class="container narrow">
     <h1>Donate</h1>
     <p class="small">
       Contributions are not tax‑deductible. Maine law requires us to collect your name and address for contributions over $10 and your employer and occupation for contributors giving more than $50 in a reporting period. Maximum contribution is $600 per person per election.
@@ -120,19 +93,11 @@
     </form>
 
     <p class="small mt-4">Questions? <a href="/privacy.html">Privacy Policy</a></p>
-  </main>
-  <footer class="footer">
-    <div class="container">
-      <!-- Required campaign disclaimer -->
-      <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-      <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207‑205‑2680</a>.</div>
-    </div>
-  </footer>
-  <!-- Include navigation script and donation helper -->
-  <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
-  <script src="/js/nav.js" defer></script>
-  <script src="/js/donationHelper.js" defer></script>
-  <script src="/js/main.js" defer></script>
-  <script src="/js/captcha.js" defer></script>
-</body>
-</html>
+    </main>
+    <!--#include virtual="/partials/footer.html" -->
+    <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
+    <script src="/js/donationHelper.js" defer></script>
+    <script src="/js/main.js" defer></script>
+    <script src="/js/captcha.js" defer></script>
+  </body>
+  </html>

--- a/events.html
+++ b/events.html
@@ -30,34 +30,7 @@
   <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main">Skip to content</a>
-  <!-- Unified sticky header -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">Donate</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!--#include virtual="/partials/header.html" -->
 
   <main id="main">
     <section class="section--alt">
@@ -87,14 +60,6 @@
     </section>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <!-- Required campaign disclaimer -->
-      <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-      <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207‑205‑2680</a>.</div>
-    </div>
-  </footer>
-  <!-- Footer + nav.js -->
-  <script src="/js/nav.js" defer></script>
+  <!--#include virtual="/partials/footer.html" -->
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -51,36 +51,7 @@
 </script>
 </head>
 <body>
-  <!-- Accessible skip link for keyboard users -->
-  <a class="skip-link" href="#main">Skip to content</a>
-
-  <!-- Unified sticky header and navigation bar -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">Donate</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!--#include virtual="/partials/header.html" -->
 
   <main id="main">
     <!-- HERO — video background (no placeholders) -->
@@ -284,18 +255,6 @@
     </section>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <!-- Required campaign disclaimer -->
-      <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-      <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email
-        <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call
-        <a href="tel:2072052680">207-205-2680</a>.
-      </div>
-    </div>
-  </footer>
-
-  <!-- Navigation and header JS -->
-  <script src="/js/nav.js" defer></script>
+  <!--#include virtual="/partials/footer.html" -->
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,9 @@
+<footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,27 @@
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/porch.html
+++ b/porch.html
@@ -33,37 +33,7 @@
   <link rel="preload" href="/assets/open-porch-banner-1600.jpg" as="image" fetchpriority="high">
 </head>
 <body>
-  <!-- Accessible skip link for keyboard users -->
-  <a class="skip-link" href="#main">Skip to content</a>
-  <!-- Unified sticky header and navigation bar -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">
-              Donate
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!--#include virtual="/partials/header.html" -->
   <!-- Open Porch banner -->
   <main id="main">
     <section
@@ -164,14 +134,6 @@
     }
     </script>
   </main>
-<footer class="footer">
-  <div class="container">
-      <!-- Required campaign disclaimer -->
-      <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
-  </div>
-</footer>
-  <!-- Navigation and header JS -->
-  <script src="/js/nav.js" defer></script>
+<!--#include virtual="/partials/footer.html" -->
 </body>
 </html>

--- a/priorities.html
+++ b/priorities.html
@@ -30,37 +30,7 @@
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
 </head>
 <body>
-  <!-- Accessible skip link for keyboard users -->
-  <a class="skip-link" href="#main">Skip to content</a>
-  <!-- Unified sticky header and navigation bar -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">
-              Donate
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!--#include virtual="/partials/header.html" -->
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
@@ -127,15 +97,7 @@
       </div>
     </section>
   </main>
-<footer class="footer">
-  <div class="container">
-    <!-- Required campaign disclaimer -->
-    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207‑205‑2680</a>.</div>
-  </div>
-</footer>
-  <!-- Navigation and header JS -->
-  <script src="/js/nav.js" defer></script>
+<!--#include virtual="/partials/footer.html" -->
   <script src="/js/priorities.js" defer></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -30,37 +30,7 @@
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
 </head>
 <body>
-  <!-- Accessible skip link for keyboard users -->
-  <a class="skip-link" href="#main">Skip to content</a>
-  <!-- Unified sticky header and navigation bar -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">
-              Donate
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!--#include virtual="/partials/header.html" -->
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
@@ -76,14 +46,6 @@
 </section>
 
 </main>
-<footer class="footer">
-  <div class="container">
-    <!-- Required campaign disclaimer -->
-    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207‑205‑2680</a>.</div>
-  </div>
-</footer>
-  <!-- Navigation and header JS -->
-  <script src="/js/nav.js" defer></script>
+<!--#include virtual="/partials/footer.html" -->
 </body>
 </html>

--- a/support.html
+++ b/support.html
@@ -30,34 +30,7 @@
   <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#main">Skip to content</a>
-  <!-- Unified sticky header and navigation bar -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">Donate</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!--#include virtual="/partials/header.html" -->
   <main id="main">
     <section class="cta" aria-labelledby="support-title">
       <div class="container">
@@ -120,13 +93,6 @@
       </div>
     </section>
   </main>
-  <footer class="footer">
-    <div class="container">
-      <!-- Required campaign disclaimer -->
-      <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-      <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207‑205‑2680</a>.</div>
-    </div>
-  </footer>
-  <script src="/js/nav.js" defer></script>
+  <!--#include virtual="/partials/footer.html" -->
 </body>
 </html>

--- a/thanks.html
+++ b/thanks.html
@@ -18,51 +18,13 @@
   <link rel="stylesheet" href="/css/styles.css?v=20250814122120" />
 </head>
 <body>
-  <!-- Accessible skip link for keyboard users -->
-  <a class="skip-link" href="#main">Skip to content</a>
-  <!-- Unified sticky header and navigation bar -->
-  <header class="header" role="banner">
-    <div class="container header__bar">
-      <a class="brand" href="/" aria-label="Home">
-        <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
-        <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
-        <span class="brand__text">Sam Pecor</span>
-      </a>
-      <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-        <span class="sr-only">Menu</span>
-        <span aria-hidden="true">☰</span>
-      </button>
-      <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
-        <ul class="nav__list">
-          <li><a href="/">Home</a></li>
-          <li><a href="/about.html">About</a></li>
-          <li><a href="/priorities.html">Priorities</a></li>
-          <li><a href="/porch.html">Open Porch</a></li>
-          <li><a href="/support.html">Support</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li class="nav__cta">
-            <a href="/donate.html" class="btn btn--donate">
-              Donate
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!--#include virtual="/partials/header.html" -->
   <main id="main" class="container">
     <h1>Thanks for reaching out!</h1>
     <p>We’ve received your submission. I’ll follow up soon. In the meantime,
        you can call or text 207-205-2680 or email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a>.</p>
     <p><a class="btn" href="/">Back to Home</a></p>
   </main>
-  <footer class="footer">
-    <div class="container">
-      <!-- Required campaign disclaimer -->
-      <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
-      <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207‑205‑2680</a>.</div>
-    </div>
-  </footer>
-  <!-- Navigation and header JS -->
-  <script src="/js/nav.js" defer></script>
+  <!--#include virtual="/partials/footer.html" -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Extract common navigation markup to `partials/header.html`
- Consolidate footer and nav script into `partials/footer.html`
- Replace repeated header/footer in all pages with server-side includes
- Add Jest test verifying partials render uniformly across pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7307ea2348330af879857abe37948