### PR TITLE
Standardize CSS cache busting

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,7 +6,7 @@
 <title>Page not found — Sam Pecor</title>
 <meta name="description" content="The page you’re looking for doesn’t exist.">
 <link rel="canonical" href="https://pecorforcouncil.com/">
-<link rel="stylesheet" href="/css/styles.css?v=20250814122120">
+<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">

--- a/about.html
+++ b/about.html
@@ -26,7 +26,7 @@
   <meta name="twitter:title" content="About — Sam Pecor">
   <meta name="twitter:description" content="Meet Sam: background, experience, and why he's running to deliver practical results for Biddeford’s Ward 7.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/contact.html
+++ b/contact.html
@@ -6,7 +6,7 @@
 <title>Contact — Sam Pecor</title>
 <meta name="description" content="Email the campaign or send a message using the contact form.">
 <link rel="canonical" href="https://pecorforcouncil.com/contact.html">
-<link rel="stylesheet" href="/css/styles.css?v=20250814122120">
+<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">

--- a/donate.html
+++ b/donate.html
@@ -27,7 +27,7 @@
   <meta name="twitter:title" content="Donate — Sam Pecor">
   <meta name="twitter:description" content="Placeholder: integrate donation provider or ActBlue link later.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/events.html
+++ b/events.html
@@ -27,7 +27,7 @@
   <meta name="twitter:title" content="Events — Sam Pecor">
   <meta name="twitter:description" content="Join Sam at upcoming events and weekly Open Porch listening sessions.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Practical, steady, and accountable local government. Learn about Sam’s plan for housing, infrastructure, and transparent budgeting.">
 <link rel="canonical" href="https://pecorforcouncil.com/">
 
-<link rel="stylesheet" href="/css/styles.css?v=20250814122120">
+<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
 
 <!-- Favicons -->
 <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Council Campaign Website",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "build": "node scripts/update-css-version.js"
   },
   "keywords": [],
   "author": "",

--- a/porch.html
+++ b/porch.html
@@ -6,7 +6,7 @@
 <title>Open Porch — Weekly Listening Sessions — Sam Pecor</title>
 <meta name="description" content="Join Sam’s weekly Open Porch to share what’s working, flag what isn’t, and shape the plan together.">
 <link rel="canonical" href="https://pecorforcouncil.com/porch.html">
-<link rel="stylesheet" href="/css/styles.css?v=20250814122120">
+<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">

--- a/priorities.html
+++ b/priorities.html
@@ -6,7 +6,7 @@
     <title>Our Plan for Biddeford — Sam Pecor</title>
     <meta name="description" content="Fix what’s broken, grow smart, and own the results. Explore priorities, goals, and next steps.">
     <link rel="canonical" href="https://pecorforcouncil.com/priorities.html">
-<link rel="stylesheet" href="/css/styles.css?v=20250814122120">
+<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">

--- a/privacy.html
+++ b/privacy.html
@@ -6,7 +6,7 @@
 <title>Privacy — Sam Pecor</title>
 <meta name="description" content="Plain‑English privacy: what we collect and why.">
 <link rel="canonical" href="https://pecorforcouncil.com/privacy.html">
-<link rel="stylesheet" href="/css/styles.css?v=20250814122120">
+<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">

--- a/scripts/update-css-version.js
+++ b/scripts/update-css-version.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const cssPath = path.join(root, 'css', 'styles.css');
+
+const version = Math.floor(fs.statSync(cssPath).mtimeMs).toString();
+
+const htmlFiles = fs
+  .readdirSync(root)
+  .filter((file) => file.endsWith('.html'));
+
+htmlFiles.forEach((file) => {
+  const filePath = path.join(root, file);
+  let content = fs.readFileSync(filePath, 'utf8');
+  content = content.replace(/\/css\/styles\.css(?:\?v=[^"']*)?/g, `/css/styles.css?v=${version}`);
+  fs.writeFileSync(filePath, content);
+});
+
+console.log(`Updated ${htmlFiles.length} HTML files with version ${version}`);

--- a/support.html
+++ b/support.html
@@ -27,7 +27,7 @@
   <meta name="twitter:title" content="Support — Sam Pecor">
   <meta name="twitter:description" content="Volunteer or receive updates from the campaign.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/thanks.html
+++ b/thanks.html
@@ -15,7 +15,7 @@
   <meta name="msapplication-config" content="/favicons/browserconfig.xml">
   <meta name="theme-color" content="#184a45">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="/css/styles.css?v=20250814122120" />
+  <link rel="stylesheet" href="/css/styles.css?v=1755787398618" />
 </head>
 <body>
   <!-- Accessible skip link for keyboard users -->


### PR DESCRIPTION
## Summary
- add build script that writes a version query for `/css/styles.css` to all HTML files
- update every HTML page to reference `/css/styles.css` with an automatic version query

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a730802e28833099e9ed5808a507e4