### PR TITLE
Use non-breaking hyphen in tagline

### DIFF
--- a/404.html
+++ b/404.html
@@ -65,7 +65,7 @@
   <section class="hero">
     <div class="container">
       <p class="hero__title">Fix what’s broken. Grow smart. Own the results.</p>
-      <p>Biddeford’s working‑class future — steady, practical, accountable.</p>
+      <p>Biddeford’s working&#8209;class future — steady, practical, accountable.</p>
     </div>
   </section>
   <main id="main" class="container">

--- a/contact.html
+++ b/contact.html
@@ -65,7 +65,7 @@
   <section class="hero">
     <div class="container">
       <p class="hero__title">Fix what’s broken. Grow smart. Own the results.</p>
-      <p>Biddeford’s working‑class future — steady, practical, accountable.</p>
+      <p>Biddeford’s working&#8209;class future — steady, practical, accountable.</p>
     </div>
   </section>
   <main id="main" class="container">

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
       <div class="container">
         <p class="hero__eyebrow">Biddeford City Council — Ward 7</p>
         <h1 class="hero__title">Fix what’s broken. Grow smart. Own the results.</h1>
-        <p class="hero__subtitle">Biddeford’s working-class future — steady, practical, accountable.</p>
+        <p class="hero__subtitle">Biddeford’s working&#8209;class future — steady, practical, accountable.</p>
         <div class="hero__actions">
           <a class="btn" href="/about.html">Learn More</a>
           <a class="btn btn--ghost" href="/support.html">Join Us</a>

--- a/priorities.html
+++ b/priorities.html
@@ -65,7 +65,7 @@
   <section class="hero">
     <div class="container">
       <p class="hero__title">Fix what’s broken. Grow smart. Own the results.</p>
-      <p>Biddeford’s working‑class future — steady, practical, accountable.</p>
+      <p>Biddeford’s working&#8209;class future — steady, practical, accountable.</p>
     </div>
   </section>
   <main id="main">

--- a/privacy.html
+++ b/privacy.html
@@ -65,7 +65,7 @@
   <section class="hero">
     <div class="container">
       <p class="hero__title">Fix what’s broken. Grow smart. Own the results.</p>
-      <p>Biddeford’s working‑class future — steady, practical, accountable.</p>
+      <p>Biddeford’s working&#8209;class future — steady, practical, accountable.</p>
     </div>
   </section>
   <main id="main" class="container">


### PR DESCRIPTION
## Summary
- Ensure "working-class" tagline uses non-breaking hyphen across index, contact, privacy, priorities, and 404 pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7309057e48330934a6db416841b6f