### PR TITLE
refactor: move banner image-set to stylesheet

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -631,6 +631,8 @@ nav a { margin-left: var(--space-4); font-weight: 600; }
 .op-banner {
   position: relative;
   color: #fff;
+  --op-banner: -webkit-image-set(url('/assets/open-porch-banner-1600.webp') type('image/webp') 1x, url('/assets/open-porch-banner-2000.webp') type('image/webp') 2x, url('/assets/open-porch-banner-1600.jpg') type('image/jpeg') 1x, url('/assets/open-porch-banner-2000.jpg') type('image/jpeg') 2x);
+  --op-banner: image-set(url('/assets/open-porch-banner-1600.webp') type('image/webp') 1x, url('/assets/open-porch-banner-2000.webp') type('image/webp') 2x, url('/assets/open-porch-banner-1600.jpg') type('image/jpeg') 1x, url('/assets/open-porch-banner-2000.jpg') type('image/jpeg') 2x);
   background-image: var(--op-banner, url('/assets/open-porch-placeholder.svg'));
   background-position: center;
   background-size: cover;

--- a/porch.html
+++ b/porch.html
@@ -68,7 +68,6 @@
   <main id="main">
     <section
       class="op-banner"
-      style="--op-banner: -webkit-image-set(url('/assets/open-porch-banner-1600.webp') type('image/webp') 1x, url('/assets/open-porch-banner-2000.webp') type('image/webp') 2x, url('/assets/open-porch-banner-1600.jpg') type('image/jpeg') 1x, url('/assets/open-porch-banner-2000.jpg') type('image/jpeg') 2x); --op-banner: image-set(url('/assets/open-porch-banner-1600.webp') type('image/webp') 1x, url('/assets/open-porch-banner-2000.webp') type('image/webp') 2x, url('/assets/open-porch-banner-1600.jpg') type('image/jpeg') 1x, url('/assets/open-porch-banner-2000.jpg') type('image/jpeg') 2x);"
       aria-label="Open Porch banner">
       <div class="container">
         <h1>Open Porch</h1>


### PR DESCRIPTION
## Summary
- move Open Porch banner image-set custom property from inline style to stylesheet
- remove inline style from porch.html to comply with CSP

## Testing
- `npm test`
- `node -e "const fs=require('fs');const {JSDOM}=require('jsdom');const html=fs.readFileSync('porch.html','utf8');const dom=new (require('jsdom').JSDOM)(html);const s=dom.window.document.querySelector('.op-banner');console.log('style attribute exists?', s.hasAttribute('style'));console.log('aria-label', s.getAttribute('aria-label'));"`


------
https://chatgpt.com/codex/tasks/task_e_68a7343e15dc83309e44b4f5f7bd1f72