### PR TITLE
Add dist build option for partials script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 
+
+dist/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # pecorforcouncil-site
+
 Council Campaign Website
+
+## Development
+
+Inline the shared header and footer into the HTML files and serve them locally:
+
+```bash
+node scripts/inline-partials.js dist
+npx serve dist
+```
+
+The script copies the site into a `dist/` directory and replaces the `<!--#include -->` directives with the content of the partials so the header and footer appear during development.

--- a/scripts/inline-partials.js
+++ b/scripts/inline-partials.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const distArg = process.argv[2];
+const outDir = distArg ? path.resolve(root, distArg) : root;
+
+// Clean and copy files if writing to a different directory
+if (outDir !== root) {
+  fs.rmSync(outDir, { recursive: true, force: true });
+  fs.mkdirSync(outDir, { recursive: true });
+  const skip = new Set(['node_modules', 'partials', 'scripts', 'dist', '__tests__']);
+  fs.readdirSync(root).forEach((entry) => {
+    if (skip.has(entry)) return;
+    fs.cpSync(path.join(root, entry), path.join(outDir, entry), { recursive: true });
+  });
+}
+
+const header = fs.readFileSync(path.join(root, 'partials', 'header.html'), 'utf8');
+const footer = fs.readFileSync(path.join(root, 'partials', 'footer.html'), 'utf8');
+
+const htmlFiles = fs
+  .readdirSync(outDir)
+  .filter((file) => file.endsWith('.html') && !file.startsWith('partial'));
+
+htmlFiles.forEach((file) => {
+  const filePath = path.join(outDir, file);
+  let content = fs.readFileSync(filePath, 'utf8');
+  content = content
+    .replace('<!--#include virtual="/partials/header.html" -->', header)
+    .replace('<!--#include virtual="/partials/footer.html" -->', footer);
+  fs.writeFileSync(filePath, content);
+});
+
+console.log(
+  `Inlined partials into ${htmlFiles.length} HTML files${outDir !== root ? ` in ${path.relative(
+    root,
+    outDir
+  )}` : ''}`
+);


### PR DESCRIPTION
## Summary
- add `scripts/inline-partials.js` to inline header/footer and optionally write to a `dist/` folder
- document running the script and serving `dist/` locally
- ignore generated `dist/` directory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73efa6cbc8330a1042e8099ae5728