### PR TITLE
Inline partials during build

### DIFF
--- a/404.html
+++ b/404.html
@@ -30,7 +30,34 @@
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
 </head>
 <body>
-  <!--#include virtual="/partials/header.html" -->
+  <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
@@ -46,6 +73,15 @@
 </section>
 
 </main>
-<!--#include virtual="/partials/footer.html" -->
+<footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
 </body>
 </html>

--- a/__tests__/partials.test.js
+++ b/__tests__/partials.test.js
@@ -21,14 +21,7 @@ describe('shared partials', () => {
     test(`${file} renders shared header and footer`, () => {
       const filePath = path.join(root, file);
       const raw = fs.readFileSync(filePath, 'utf8');
-      expect(raw).toContain('<!--#include virtual="/partials/header.html" -->');
-      expect(raw).toContain('<!--#include virtual="/partials/footer.html" -->');
-
-      const rendered = raw
-        .replace('<!--#include virtual="/partials/header.html" -->', headerPartial)
-        .replace('<!--#include virtual="/partials/footer.html" -->', footerPartial);
-
-      const dom = new JSDOM(rendered);
+      const dom = new JSDOM(raw);
       const header = dom.window.document.querySelector('header').outerHTML;
       const skip = dom.window.document.querySelector('.skip-link').outerHTML;
       const footer = dom.window.document.querySelector('footer').outerHTML;

--- a/about.html
+++ b/about.html
@@ -29,7 +29,34 @@
   <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
 </head>
 <body>
-  <!--#include virtual="/partials/header.html" -->
+  <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
   <main id="main">
     <!-- Page intro -->
     <section class="section--alt">
@@ -95,6 +122,15 @@
     </section>
   </main>
 
-  <!--#include virtual="/partials/footer.html" -->
+  <footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -30,7 +30,34 @@
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
 </head>
 <body>
-  <!--#include virtual="/partials/header.html" -->
+  <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
@@ -58,7 +85,16 @@
 </section>
 
   </main>
-  <!--#include virtual="/partials/footer.html" -->
+  <footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
   <script src="/js/captcha.js" defer></script>
   </body>

--- a/donate.html
+++ b/donate.html
@@ -30,7 +30,34 @@
   <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
 </head>
   <body>
-    <!--#include virtual="/partials/header.html" -->
+    <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
     <main id="main" class="container narrow">
     <h1>Donate</h1>
     <p class="small">
@@ -94,7 +121,16 @@
 
     <p class="small mt-4">Questions? <a href="/privacy.html">Privacy Policy</a></p>
     </main>
-    <!--#include virtual="/partials/footer.html" -->
+    <footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
     <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
     <script src="/js/donationHelper.js" defer></script>
     <script src="/js/main.js" defer></script>

--- a/events.html
+++ b/events.html
@@ -30,7 +30,34 @@
   <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
 </head>
 <body>
-  <!--#include virtual="/partials/header.html" -->
+  <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
 
   <main id="main">
     <section class="section--alt">
@@ -60,6 +87,15 @@
     </section>
   </main>
 
-  <!--#include virtual="/partials/footer.html" -->
+  <footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,34 @@
 </script>
 </head>
 <body>
-  <!--#include virtual="/partials/header.html" -->
+  <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
 
   <main id="main">
     <!-- HERO — video background (no placeholders) -->
@@ -255,6 +282,15 @@
     </section>
   </main>
 
-  <!--#include virtual="/partials/footer.html" -->
+  <footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "build": "node scripts/update-css-version.js"
+    "inline": "node scripts/inline-partials.js",
+    "build": "npm run inline && node scripts/update-css-version.js"
   },
   "keywords": [],
   "author": "",

--- a/porch.html
+++ b/porch.html
@@ -33,7 +33,34 @@
   <link rel="preload" href="/assets/open-porch-banner-1600.jpg" as="image" fetchpriority="high">
 </head>
 <body>
-  <!--#include virtual="/partials/header.html" -->
+  <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
   <!-- Open Porch banner -->
   <main id="main">
     <section
@@ -133,6 +160,15 @@
     }
     </script>
   </main>
-<!--#include virtual="/partials/footer.html" -->
+<footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
 </body>
 </html>

--- a/priorities.html
+++ b/priorities.html
@@ -30,7 +30,34 @@
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
 </head>
 <body>
-  <!--#include virtual="/partials/header.html" -->
+  <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
@@ -97,7 +124,16 @@
       </div>
     </section>
   </main>
-<!--#include virtual="/partials/footer.html" -->
+<footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
   <script src="/js/priorities.js" defer></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -30,7 +30,34 @@
     <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
 </head>
 <body>
-  <!--#include virtual="/partials/header.html" -->
+  <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
   <!-- Hero section with tagline -->
   <section class="hero">
     <div class="container">
@@ -46,6 +73,15 @@
 </section>
 
 </main>
-<!--#include virtual="/partials/footer.html" -->
+<footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
 </body>
 </html>

--- a/scripts/inline-partials.js
+++ b/scripts/inline-partials.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+
+const distArg = process.argv[2];
+const outDir = distArg ? path.resolve(root, distArg) : root;
+
+function copyRecursive(src, dest, skip = new Set()) {
+  if (skip.has(path.basename(src))) return;
+  const stat = fs.statSync(src);
+  if (stat.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    for (const entry of fs.readdirSync(src)) {
+      copyRecursive(path.join(src, entry), path.join(dest, entry), skip);
+    }
+  } else {
+    fs.copyFileSync(src, dest);
+  }
+}
+
+// Clean and copy files if writing to a different directory
+if (outDir !== root) {
+  if (fs.existsSync(outDir)) {
+    // Use rmSync when available; fall back to rmdirSync for older Node versions
+    if (fs.rmSync) fs.rmSync(outDir, { recursive: true, force: true });
+    else fs.rmdirSync(outDir, { recursive: true });
+  }
+  fs.mkdirSync(outDir, { recursive: true });
+  const skip = new Set(['node_modules', 'partials', 'scripts', 'dist', '__tests__']);
+  for (const entry of fs.readdirSync(root)) {
+    copyRecursive(path.join(root, entry), path.join(outDir, entry), skip);
+  }
+}
+
+const header = fs.readFileSync(path.join(root, 'partials', 'header.html'), 'utf8');
+const footer = fs.readFileSync(path.join(root, 'partials', 'footer.html'), 'utf8');
+
+const htmlFiles = fs
+  .readdirSync(outDir)
+  .filter((file) => file.endsWith('.html') && !file.startsWith('partial'));
+
+htmlFiles.forEach((file) => {
+  const filePath = path.join(outDir, file);
+  let content = fs.readFileSync(filePath, 'utf8');
+  content = content
+    .replace(/<!--#include virtual="\/partials\/header\.html"\s*-->/g, header)
+    .replace(/<!--#include virtual="\/partials\/footer\.html"\s*-->/g, footer);
+  fs.writeFileSync(filePath, content);
+});
+
+console.log(
+  `Inlined partials into ${htmlFiles.length} HTML files${outDir !== root ? ` in ${path.relative(
+    root,
+    outDir
+  )}` : ''}`
+);

--- a/support.html
+++ b/support.html
@@ -30,7 +30,34 @@
   <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
 </head>
 <body>
-  <!--#include virtual="/partials/header.html" -->
+  <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
   <main id="main">
     <section class="cta" aria-labelledby="support-title">
       <div class="container">
@@ -93,6 +120,15 @@
       </div>
     </section>
   </main>
-  <!--#include virtual="/partials/footer.html" -->
+  <footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
 </body>
 </html>

--- a/thanks.html
+++ b/thanks.html
@@ -18,13 +18,49 @@
   <link rel="stylesheet" href="/css/styles.css?v=1755787398618" />
 </head>
 <body>
-  <!--#include virtual="/partials/header.html" -->
+  <a class="skip-link" href="#main">Skip to content</a>
+<header class="header" role="banner">
+  <div class="container header__bar">
+    <a class="brand" href="/" aria-label="Home">
+      <!-- Use the campaign favicon as the brand mark instead of the placeholder SP badge -->
+      <img src="/favicons/favicon-32x32.png" alt="Campaign logo" class="brand__logo">
+      <span class="brand__text">Sam Pecor</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span aria-hidden="true">☰</span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="Primary" aria-hidden="true">
+      <ul class="nav__list">
+        <li><a href="/">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/priorities.html">Priorities</a></li>
+        <li><a href="/porch.html">Open Porch</a></li>
+        <li><a href="/support.html">Support</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+        <li class="nav__cta">
+          <a href="/donate.html" class="btn btn--donate">Donate</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
   <main id="main" class="container">
     <h1>Thanks for reaching out!</h1>
     <p>We’ve received your submission. I’ll follow up soon. In the meantime,
        you can call or text 207-205-2680 or email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a>.</p>
     <p><a class="btn" href="/">Back to Home</a></p>
   </main>
-  <!--#include virtual="/partials/footer.html" -->
+  <footer class="footer">
+  <div class="container">
+    <!-- Required campaign disclaimer -->
+    <p class="small footer-disclaimer">Paid for and authorized by Sam Pecor.</p>
+    <div class="small">© 2025 Pecor for Council. Accessibility: need accommodations? Email <a href="mailto:info@pecorforcouncil.com">info@pecorforcouncil.com</a> or call <a href="tel:2072052680">207-205-2680</a>.</div>
+  </div>
+</footer>
+<!-- Navigation and header JS -->
+<script src="/js/nav.js" defer></script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add inline-partials script to replace SSI header/footer includes in HTML files
- run new inline step from build process
- update tests for inlined markup
- allow script to copy source into an output directory before inlining
- use regex for global header/footer replacements
- avoid modern fs APIs in inline script for broader Node support

## Testing
- `npm run inline`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73ef4ff2883309b0df8d4ed8f8547