### PR TITLE
Inline footer partials during build

### DIFF
--- a/__tests__/partials.test.js
+++ b/__tests__/partials.test.js
@@ -15,27 +15,39 @@ const expectedHeader = headerDOM.window.document.querySelector('header').outerHT
 const expectedSkip = headerDOM.window.document.querySelector('.skip-link').outerHTML;
 const footerDOM = new JSDOM(footerPartial);
 const expectedFooter = footerDOM.window.document.querySelector('footer').outerHTML;
+const footerDisclaimer = footerDOM.window.document
+  .querySelector('.footer-disclaimer')
+  .textContent.trim();
+
+const headerIncludeRE = /<!--#\s*include\s+virtual=['"]\/partials\/header\.html['"]\s*-->/i;
+const footerIncludeRE = /<!--#\s*include\s+virtual=['"]\/partials\/footer[^'"]*\.html['"]\s*-->/i;
 
 describe('shared partials', () => {
   htmlFiles.forEach((file) => {
     test(`${file} renders shared header and footer`, () => {
       const filePath = path.join(root, file);
       const raw = fs.readFileSync(filePath, 'utf8');
-      expect(raw).toContain('<!--#include virtual="/partials/header.html" -->');
-      expect(raw).toContain('<!--#include virtual="/partials/footer.html" -->');
+      expect(raw).toMatch(headerIncludeRE);
+      expect(raw).toMatch(footerIncludeRE);
 
       const rendered = raw
-        .replace('<!--#include virtual="/partials/header.html" -->', headerPartial)
-        .replace('<!--#include virtual="/partials/footer.html" -->', footerPartial);
+        .replace(headerIncludeRE, headerPartial)
+        .replace(footerIncludeRE, footerPartial);
 
       const dom = new JSDOM(rendered);
       const header = dom.window.document.querySelector('header').outerHTML;
       const skip = dom.window.document.querySelector('.skip-link').outerHTML;
       const footer = dom.window.document.querySelector('footer').outerHTML;
+      const disclaimer = dom.window.document
+        .querySelector('.footer-disclaimer')
+        .textContent.trim();
+      const navScript = dom.window.document.querySelector('script[src="/js/nav.js"]');
 
       expect(header).toBe(expectedHeader);
       expect(skip).toBe(expectedSkip);
       expect(footer).toBe(expectedFooter);
+      expect(disclaimer).toBe(footerDisclaimer);
+      expect(navScript).not.toBeNull();
     });
   });
 });

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[functions]
+  directory = "netlify/functions"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "build": "node scripts/update-css-version.js"
+    "inline": "node scripts/inline-partials.js dist",
+    "build": "npm run inline && node scripts/update-css-version.js dist"
   },
   "keywords": [],
   "author": "",

--- a/scripts/inline-partials.js
+++ b/scripts/inline-partials.js
@@ -19,6 +19,9 @@ if (outDir !== root) {
 const header = fs.readFileSync(path.join(root, 'partials', 'header.html'), 'utf8');
 const footer = fs.readFileSync(path.join(root, 'partials', 'footer.html'), 'utf8');
 
+const headerIncludeRE = /<!--#\s*include\s+virtual=['"]\/partials\/header\.html['"]\s*-->/gi;
+const footerIncludeRE = /<!--#\s*include\s+virtual=['"]\/partials\/footer[^'"]*\.html['"]\s*-->/gi;
+
 const htmlFiles = fs
   .readdirSync(outDir)
   .filter((file) => file.endsWith('.html') && !file.startsWith('partial'));
@@ -26,9 +29,7 @@ const htmlFiles = fs
 htmlFiles.forEach((file) => {
   const filePath = path.join(outDir, file);
   let content = fs.readFileSync(filePath, 'utf8');
-  content = content
-    .replace('<!--#include virtual="/partials/header.html" -->', header)
-    .replace('<!--#include virtual="/partials/footer.html" -->', footer);
+  content = content.replace(headerIncludeRE, header).replace(footerIncludeRE, footer);
   fs.writeFileSync(filePath, content);
 });
 

--- a/scripts/update-css-version.js
+++ b/scripts/update-css-version.js
@@ -2,16 +2,18 @@ const fs = require('fs');
 const path = require('path');
 
 const root = path.join(__dirname, '..');
-const cssPath = path.join(root, 'css', 'styles.css');
+const distArg = process.argv[2];
+const outDir = distArg ? path.resolve(root, distArg) : root;
+const cssPath = path.join(outDir, 'css', 'styles.css');
 
 const version = Math.floor(fs.statSync(cssPath).mtimeMs).toString();
 
 const htmlFiles = fs
-  .readdirSync(root)
+  .readdirSync(outDir)
   .filter((file) => file.endsWith('.html'));
 
 htmlFiles.forEach((file) => {
-  const filePath = path.join(root, file);
+  const filePath = path.join(outDir, file);
   let content = fs.readFileSync(filePath, 'utf8');
   content = content.replace(/\/css\/styles\.css(?:\?v=[^"']*)?/g, `/css/styles.css?v=${version}`);
   fs.writeFileSync(filePath, content);


### PR DESCRIPTION
## Summary
- Inline header and footer includes using robust regex to handle all footer variants.
- Add Netlify build step and npm scripts to run `inline` before packaging, with CSS versioning support for `dist`.
- Expand partial tests to cover footer disclaimer text and `nav.js` script.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a87a0a50a08330abc8da3011c250f6