### PR TITLE
Align about page headshot with heading

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,7 +6,7 @@
 <title>Page not found — Sam Pecor</title>
 <meta name="description" content="The page you’re looking for doesn’t exist.">
 <link rel="canonical" href="https://pecorforcouncil.com/">
-<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
+<link rel="stylesheet" href="/css/styles.css?v=1755878263420">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">

--- a/about.html
+++ b/about.html
@@ -26,7 +26,7 @@
   <meta name="twitter:title" content="About — Sam Pecor">
   <meta name="twitter:description" content="Meet Sam: background, experience, and why he's running to deliver practical results for Biddeford’s Ward 7.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
+  <link rel="stylesheet" href="/css/styles.css?v=1755878263420">
 </head>
 <body>
   <!--#include virtual="/partials/header.html" -->
@@ -62,7 +62,7 @@
             <li>Avid student of housing, economics, history, science, and public affairs; currently reading biographies of each U.S. president to better understand our civic experiment and how we got here.</li>
           </ul>
 
-          <div class="about__actions" style="margin-top: var(--space-6);">
+          <div class="about__actions">
             <a class="btn" href="/priorities.html">View priorities</a>
             <a class="btn btn--ghost" href="/support.html">Join the campaign</a>
           </div>

--- a/contact.html
+++ b/contact.html
@@ -6,7 +6,7 @@
 <title>Contact — Sam Pecor</title>
 <meta name="description" content="Email the campaign or send a message using the contact form.">
 <link rel="canonical" href="https://pecorforcouncil.com/contact.html">
-<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
+<link rel="stylesheet" href="/css/styles.css?v=1755878263420">
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">

--- a/css/styles.css
+++ b/css/styles.css
@@ -92,6 +92,16 @@ h1 { font-size: var(--fs-xxl); }
 h2 { font-size: var(--fs-xl); }
 h3 { font-size: var(--fs-lg); }
 
+.kicker {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  margin: 0 0 var(--space-2);
+  line-height: 1;
+  color: var(--color-muted);
+}
+
 /* =========================
    Containers & Sections
    ========================= */
@@ -530,8 +540,9 @@ nav a { margin-left: var(--space-4); font-weight: 600; }
   display: grid;
   grid-template-columns: 1.1fr 0.9fr;
   gap: clamp(var(--space-6), 4vw, var(--space-10));
-  align-items: center;
+  align-items: flex-start;
 }
+.about__content h1 { margin-top: 0; }
 .about__content h2 { margin-top: 0; }
 .about__lede {
   font-size: clamp(1.05rem, 2vw, 1.25rem);
@@ -539,8 +550,8 @@ nav a { margin-left: var(--space-4); font-weight: 600; }
   margin: var(--space-3) 0 var(--space-6);
   max-width: 65ch;
 }
-.about__actions { display: flex; gap: var(--space-3); flex-wrap: wrap; }
-.about__media { max-width: 520px; justify-self: center; }
+.about__actions { display: flex; gap: var(--space-3); flex-wrap: wrap; margin-top: var(--space-6); }
+.about__media { max-width: 520px; justify-self: center; margin-top: calc(var(--fs-xs) + var(--space-2)); }
 .media-frame {
   border-radius: var(--radius-xl);
   overflow: hidden;
@@ -555,7 +566,7 @@ nav a { margin-left: var(--space-4); font-weight: 600; }
 
 @media (max-width: 900px) {
   .about { grid-template-columns: 1fr; }
-  .about__media { order: -1; }
+  .about__media { order: -1; margin-top: 0; }
 }
 
 /* Chips */

--- a/donate.html
+++ b/donate.html
@@ -27,7 +27,7 @@
   <meta name="twitter:title" content="Donate — Sam Pecor">
   <meta name="twitter:description" content="Contribute to support Sam’s campaign. Contributions are not tax-deductible; Maine law requires us to collect your name and address for gifts over $10 and your employer and occupation for gifts over $50. Max contribution: $600 per election.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
+  <link rel="stylesheet" href="/css/styles.css?v=1755878263420">
 </head>
   <body>
     <!--#include virtual="/partials/header.html" -->

--- a/events.html
+++ b/events.html
@@ -27,7 +27,7 @@
   <meta name="twitter:title" content="Events — Sam Pecor">
   <meta name="twitter:description" content="Join Sam at upcoming events and weekly Open Porch listening sessions.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
+  <link rel="stylesheet" href="/css/styles.css?v=1755878263420">
 </head>
 <body>
   <!--#include virtual="/partials/header.html" -->

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Practical, steady, and accountable local government. Learn about Sam’s plan for housing, infrastructure, and transparent budgeting.">
 <link rel="canonical" href="https://pecorforcouncil.com/">
 
-<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
+<link rel="stylesheet" href="/css/styles.css?v=1755878263420">
 
 <!-- Favicons -->
 <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">

--- a/porch.html
+++ b/porch.html
@@ -6,7 +6,7 @@
 <title>Open Porch — Weekly Listening Sessions — Sam Pecor</title>
 <meta name="description" content="Join Sam’s weekly Open Porch to share what’s working, flag what isn’t, and shape the plan together.">
 <link rel="canonical" href="https://pecorforcouncil.com/porch.html">
-<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
+<link rel="stylesheet" href="/css/styles.css?v=1755878263420">
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">

--- a/priorities.html
+++ b/priorities.html
@@ -6,7 +6,7 @@
     <title>Our Plan for Biddeford — Sam Pecor</title>
     <meta name="description" content="Fix what’s broken, grow smart, and own the results. Explore priorities, goals, and next steps.">
     <link rel="canonical" href="https://pecorforcouncil.com/priorities.html">
-<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
+<link rel="stylesheet" href="/css/styles.css?v=1755878263420">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">

--- a/privacy.html
+++ b/privacy.html
@@ -6,7 +6,7 @@
 <title>Privacy — Sam Pecor</title>
 <meta name="description" content="Plain‑English privacy: what we collect and why.">
 <link rel="canonical" href="https://pecorforcouncil.com/privacy.html">
-<link rel="stylesheet" href="/css/styles.css?v=1755787398618">
+<link rel="stylesheet" href="/css/styles.css?v=1755878263420">
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">

--- a/support.html
+++ b/support.html
@@ -27,7 +27,7 @@
   <meta name="twitter:title" content="Support — Sam Pecor">
   <meta name="twitter:description" content="Volunteer or receive updates from the campaign.">
   <meta name="twitter:image" content="https://pecorforcouncil.com/assets/og-default.svg">
-  <link rel="stylesheet" href="/css/styles.css?v=1755787398618">
+  <link rel="stylesheet" href="/css/styles.css?v=1755878263420">
 </head>
 <body>
   <!--#include virtual="/partials/header.html" -->

--- a/thanks.html
+++ b/thanks.html
@@ -15,7 +15,7 @@
   <meta name="msapplication-config" content="/favicons/browserconfig.xml">
   <meta name="theme-color" content="#184a45">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="/css/styles.css?v=1755787398618" />
+  <link rel="stylesheet" href="/css/styles.css?v=1755878263420" />
 </head>
 <body>
   <!--#include virtual="/partials/header.html" -->


### PR DESCRIPTION
## Summary
- Align candidate headshot with "Meet Sam Pecor" heading on desktop
- Add reusable `.kicker` text style and clean up About page actions
- Update stylesheet version cache-busting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a892c66bc083308a178051d992d5c9