### PR TITLE
refactor accordion headings

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -528,6 +528,22 @@ nav a { margin-left: var(--space-4); font-weight: 600; }
 }
 
 /* =========================
+   Priorities accordion
+   ========================= */
+.prio-accordion summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  list-style: none;
+  margin: var(--space-6) 0 var(--space-3);
+  font-size: var(--fs-xl);
+  font-weight: 700;
+  line-height: 1.2;
+}
+.prio-accordion summary::-webkit-details-marker { display: none; }
+.prio-accordion summary .summary-text { display: inline; }
+
+/* =========================
    Home: Priorities intro
    ========================= */
 .section-title { margin: 0 0 var(--space-2); }

--- a/priorities.html
+++ b/priorities.html
@@ -70,8 +70,9 @@
         <details id="p1" open>
           <summary>
             <span class="caret" aria-hidden="true">▶</span>
-            <h2><span class="kicker">Priority #1</span> — <strong>Homes &amp; Land Use</strong></h2>
+            <span class="summary-text"><span class="kicker">Priority #1</span> — <strong>Homes &amp; Land Use</strong></span>
           </summary>
+          <h2 class="sr-only"><span class="kicker">Priority #1</span> — <strong>Homes &amp; Land Use</strong></h2>
           <div class="prio-content">
             <p class="small">Unlock “missing‑middle” homes (2–19 units), streamline review, and fit new housing to existing neighborhoods.</p>
             <ul>
@@ -87,8 +88,9 @@
         <details id="p2">
           <summary>
             <span class="caret" aria-hidden="true">▶</span>
-            <h2><span class="kicker">Priority #2</span> — <strong>Economy, Education &amp; Fiscal Stewardship</strong></h2>
+            <span class="summary-text"><span class="kicker">Priority #2</span> — <strong>Economy, Education &amp; Fiscal Stewardship</strong></span>
           </summary>
+          <h2 class="sr-only"><span class="kicker">Priority #2</span> — <strong>Economy, Education &amp; Fiscal Stewardship</strong></h2>
           <div class="prio-content">
             <p class="small">Help small businesses, grow local talent, and keep budgets honest and readable.</p>
             <ul>
@@ -104,8 +106,9 @@
         <details id="p3">
           <summary>
             <span class="caret" aria-hidden="true">▶</span>
-            <h2><span class="kicker">Priority #3</span> — <strong>Streets &amp; Transit</strong></h2>
+            <span class="summary-text"><span class="kicker">Priority #3</span> — <strong>Streets &amp; Transit</strong></span>
           </summary>
+          <h2 class="sr-only"><span class="kicker">Priority #3</span> — <strong>Streets &amp; Transit</strong></h2>
           <div class="prio-content">
             <p class="small">Sidewalks first, safer crossings, better bus links, and a bikeable network.</p>
             <ul>
@@ -121,8 +124,9 @@
         <details id="p4">
           <summary>
             <span class="caret" aria-hidden="true">▶</span>
-            <h2><span class="kicker">Priority #4</span> — <strong>Infrastructure &amp; Resilience</strong></h2>
+            <span class="summary-text"><span class="kicker">Priority #4</span> — <strong>Infrastructure &amp; Resilience</strong></span>
           </summary>
+          <h2 class="sr-only"><span class="kicker">Priority #4</span> — <strong>Infrastructure &amp; Resilience</strong></h2>
           <div class="prio-content">
             <p class="small">Water, sewer, and stormwater upgrades that reduce flooding and keep costs predictable; “fix once, fix right.”</p>
             <ul>
@@ -138,8 +142,9 @@
         <details id="p5">
           <summary>
             <span class="caret" aria-hidden="true">▶</span>
-            <h2><span class="kicker">Priority #5</span> — <strong>Health, Safety &amp; Environment</strong></h2>
+            <span class="summary-text"><span class="kicker">Priority #5</span> — <strong>Health, Safety &amp; Environment</strong></span>
           </summary>
+          <h2 class="sr-only"><span class="kicker">Priority #5</span> — <strong>Health, Safety &amp; Environment</strong></h2>
           <div class="prio-content">
             <p class="small">Healthy homes, clean air and water, safer public spaces, and coordinated responses to substance‑use and mental‑health challenges.</p>
             <ul>
@@ -155,8 +160,9 @@
         <details id="p6">
           <summary>
             <span class="caret" aria-hidden="true">▶</span>
-            <h2><span class="kicker">Priority #6</span> — <strong>Waste &amp; Resource Recovery</strong></h2>
+            <span class="summary-text"><span class="kicker">Priority #6</span> — <strong>Waste &amp; Resource Recovery</strong></span>
           </summary>
+          <h2 class="sr-only"><span class="kicker">Priority #6</span> — <strong>Waste &amp; Resource Recovery</strong></h2>
           <div class="prio-content">
             <p class="small">Cut trash, save money, and build a local reuse economy.</p>
             <ul>


### PR DESCRIPTION
## Summary
- refactor priorities accordion to use inline summary text and sr-only h2 headings
- style accordion summaries via CSS for heading appearance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68add24dc5f88330bf33fd73cb2ff7d9