### PR TITLE
Use absolute scroll for priority hash links

### DIFF
--- a/__tests__/prioritiesHash.test.js
+++ b/__tests__/prioritiesHash.test.js
@@ -9,11 +9,12 @@ describe('priorities hash handling', () => {
     global.window = window;
     global.document = window.document;
     global.location = window.location;
-    window.requestAnimationFrame = (fn) => fn();
-    window.scrollBy = jest.fn();
-    global.requestAnimationFrame = window.requestAnimationFrame;
+    window.scrollTo = jest.fn();
     global.getComputedStyle = () => ({ getPropertyValue: () => '0' });
-    document.querySelector = jest.fn(() => ({ nodeName: 'details' }));
+    document.querySelector = jest.fn(() => ({
+      nodeName: 'details',
+      getBoundingClientRect: () => ({ top: 0 }),
+    }));
 
     jest.isolateModules(() => {
       require('../js/priorities');
@@ -30,7 +31,6 @@ describe('priorities hash handling', () => {
     delete global.document;
     delete global.location;
     delete global.getComputedStyle;
-    delete global.requestAnimationFrame;
   });
 
   test('ignores malicious hashes', () => {

--- a/js/priorities.js
+++ b/js/priorities.js
@@ -8,12 +8,19 @@
     if (!allowed.test(hash)) return;
 
     const el = document.querySelector(`#${hash}`);
-    if (el && el.nodeName.toLowerCase() === 'details') {
+    if (!el) return;
+
+    if (el.nodeName.toLowerCase() === 'details') {
       el.open = true;
     }
-    // Adjust scroll to account for sticky header using computed height
-    const headerH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--header-h')) || 80;
-    requestAnimationFrame(() => window.scrollBy(0, -headerH));
+
+    // Compute target offset to account for sticky header and scroll
+    const headerH =
+      parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue('--header-h')
+      ) || 80;
+    const y = el.getBoundingClientRect().top + window.scrollY - headerH;
+    window.scrollTo({ top: y, behavior: 'smooth' });
   };
   window.addEventListener('hashchange', hashOpen);
   // Run on initial page load in case a hash is present


### PR DESCRIPTION
## Summary
- open priority details and jump with one absolute scroll
- adjust tests for new scrolling logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add9f6c0f08330a5e53e5bc5779dab